### PR TITLE
Updates we added to help for ease of network verification - logging, convenience methods, and readme additions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ The network-map service requires the notaries that will comprise the compatibili
 
 java -jar
 
+    Use of --nodesDirectoryUrl is optional.  The app defaults the location_of_folder_containing_notary_nodes to classpath:nodes.
+    
     java -jar <path_to_artifact> --nodesDirectoryUrl=<location_of_folder_containing_notary_nodes>
+
+Note: The application
+leverages sqlite to persiste notaries.  If the application has been started, the nodes directory has been processed, and the 
+node information has been persisted then start up will read from the database and no longer look to the nodes directory.  If you 
+wish to reload.  Simply delete the /<workspace_path>/spring-boot-network-map/network_map.db    
     
 docker
     

--- a/src/main/kotlin/net/corda/network/map/NetworkMapApi.kt
+++ b/src/main/kotlin/net/corda/network/map/NetworkMapApi.kt
@@ -13,12 +13,14 @@ import net.corda.core.node.NetworkParameters
 import net.corda.core.serialization.SerializedBytes
 import net.corda.core.serialization.deserialize
 import net.corda.core.serialization.serialize
+import net.corda.core.utilities.loggerFor
 import net.corda.nodeapi.internal.DEV_ROOT_CA
 import net.corda.nodeapi.internal.SignedNodeInfo
 import net.corda.nodeapi.internal.crypto.CertificateAndKeyPair
 import net.corda.nodeapi.internal.crypto.CertificateType
 import net.corda.nodeapi.internal.crypto.X509Utilities
 import net.corda.nodeapi.internal.network.NetworkMap
+import org.slf4j.Logger
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -55,6 +57,9 @@ class NetworkMapApi(
     private val executorService = Executors.newSingleThreadExecutor()
     private val networkMap: AtomicReference<SerializedBytes<SignedDataWithCert<NetworkMap>>> = AtomicReference()
 
+    companion object {
+        val logger: Logger = loggerFor<NetworkMapApi>()
+    }
 
     init {
 
@@ -87,7 +92,12 @@ class NetworkMapApi(
 
     @RequestMapping(path = ["network-map/publish"], method = [RequestMethod.POST])
     fun postNodeInfo(@RequestBody input: ByteArray): DeferredResult<ResponseEntity<String>> {
+        logger.debug("Processing network-map/publish")
+
         val deserializedSignedNodeInfo = input.deserialize<SignedNodeInfo>()
+
+        logger.info("Processing network-map/publish for " + deserializedSignedNodeInfo.verified().legalIdentities)
+
         deserializedSignedNodeInfo.verified()
         nodeInfoRepository.persistSignedNodeInfo(deserializedSignedNodeInfo)
         val result = DeferredResult<ResponseEntity<String>>()
@@ -100,6 +110,9 @@ class NetworkMapApi(
 
     @RequestMapping(path = ["network-map/node-info/{hash}"], method = [RequestMethod.GET])
     fun getNodeInfo(@PathVariable("hash") input: String): ResponseEntity<ByteArray>? {
+
+        logger.info("Processing retrieval of nodeInfo for {$input}.")
+
         val (_, bytes) = nodeInfoRepository.getSignedNodeInfo(input)
         return ResponseEntity.ok()
                 .contentLength(bytes.size.toLong())
@@ -109,6 +122,9 @@ class NetworkMapApi(
 
     @RequestMapping(path = ["network-map"], method = [RequestMethod.GET])
     fun getNetworkMap(): ResponseEntity<ByteArray> {
+
+        logger.debug("Processing method to obtain network map.")
+
         return if (networkMap.get() != null) {
             val networkMapBytes = networkMap.get().bytes
             ResponseEntity.ok()
@@ -123,6 +139,9 @@ class NetworkMapApi(
 
     @RequestMapping(method = [RequestMethod.GET], path = ["network-map/network-parameters/{hash}"], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
     fun getNetworkParams(@PathVariable("hash") h: String): ResponseEntity<ByteArray> {
+
+        logger.info("Processing retrieval of network params for {$h}.")
+
         return if (SecureHash.parse(h) == networkParametersHash) {
             ResponseEntity.ok().header("Cache-Control", "max-age=${ThreadLocalRandom.current().nextInt(10, 30)}")
                     .body(networkParams.signWithCert(keyPair.private, networkMapCert).serialize().bytes)
@@ -133,6 +152,9 @@ class NetworkMapApi(
 
     private fun buildNetworkMap(): SerializedBytes<SignedDataWithCert<NetworkMap>> {
         val allNodes = nodeInfoRepository.getAllHashes()
+
+        logger.info("Processing retrieval of allNodes from the db and found {${allNodes.size}}.")
+
         val signedNetworkParams = networkParams.signWithCert(keyPair.private, networkMapCert)
         return NetworkMap(allNodes, signedNetworkParams.raw.hash, null).signWithCert(keyPair.private, networkMapCert).serialize()
     }
@@ -147,6 +169,40 @@ class NetworkMapApi(
                 X500Principal("CN=Network Map,O=R3 Ltd,L=London,C=GB"),
                 keyPair.public)
         return CertificateAndKeyPair(cert, keyPair)
+    }
+
+    @ResponseBody
+    @RequestMapping(method = [RequestMethod.GET], value = ["network-map/reset-persisted-nodes"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun resetPersistedNodes() : ResponseEntity<String> {
+        val result = nodeInfoRepository.purgeAllPersistedSignedNodeInfos()
+        val resultMsg = "Deleted : {$result} rows."
+        logger.info(resultMsg)
+        return ResponseEntity(resultMsg, HttpStatus.ACCEPTED)
+    }
+
+    @ResponseBody
+    @RequestMapping(method = [RequestMethod.GET], value = ["network-map/map-stats"], produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun fetchMapState(): SimpleMapState{
+        val stats = SimpleMapState()
+
+        networkParams.notaries.forEach {
+            stats.notaryNames.add("organisationUnit=" + it.identity.name.organisationUnit + " organisation=" + it.identity.name.organisation  + " locality=" + it.identity.name.locality +" country=" + it.identity.name.country)
+        }
+
+        val allNodes = nodeInfoRepository.getAllHashes()
+
+        allNodes.forEach {
+            val pair : Pair<SignedNodeInfo, ByteArray> = nodeInfoRepository.getSignedNodeInfo(it.toString())
+            val orgName = pair.first.verified().legalIdentities[0].name.organisation
+            stats.nodeNames.add(orgName)
+        }
+
+        return stats
+    }
+
+    class SimpleMapState {
+        val nodeNames : MutableList<String> = emptyList<String>().toMutableList()
+        val notaryNames : MutableList<String> = emptyList<String>().toMutableList()
     }
 
 }

--- a/src/main/kotlin/net/corda/network/map/NodeInfoRepository.kt
+++ b/src/main/kotlin/net/corda/network/map/NodeInfoRepository.kt
@@ -15,4 +15,5 @@ interface NodeInfoRepository {
     fun persistSignedNodeInfo(signedNodeInfo: SignedNodeInfo)
     fun getSignedNodeInfo(hash: String): Pair<SignedNodeInfo, ByteArray>
     fun getAllHashes(): List<SecureHash>
+    fun purgeAllPersistedSignedNodeInfos() : Int
 }

--- a/src/main/kotlin/net/corda/network/map/sqllite/SqlLiteNodeInfoRepository.kt
+++ b/src/main/kotlin/net/corda/network/map/sqllite/SqlLiteNodeInfoRepository.kt
@@ -22,6 +22,7 @@ import javax.annotation.PostConstruct
 @Repository
 class SqlLiteNodeInfoRepository(@Value("\${db.location:network_map.db}") dbLocation: String,
                                 @SuppressWarnings("unused") @Autowired ignored: SerializationEngine) : SqlLiteRepository(dbLocation), NodeInfoRepository {
+
     @PostConstruct
     fun connect() {
         dataSource.write {
@@ -63,8 +64,14 @@ class SqlLiteNodeInfoRepository(@Value("\${db.location:network_map.db}") dbLocat
         }
     }
 
+    override fun purgeAllPersistedSignedNodeInfos() : Int {
+        return dataSource.write {
+            it.prepareStatement(DELETE_ALL_NODE_INFO_SQL).executeUpdate()
+        }
+    }
 
     companion object {
+
         private const val BUILD_TABLE_SQL = ("CREATE TABLE IF NOT EXISTS SIGNED_NODE_INFOS (\n"
                 + "	hash TEXT PRIMARY KEY,\n"
                 + "	data BLOB NOT NULL\n"
@@ -80,6 +87,9 @@ class SqlLiteNodeInfoRepository(@Value("\${db.location:network_map.db}") dbLocat
                 "SELECT data FROM SIGNED_NODE_INFOS WHERE hash=?;"
 
         private const val GET_ALL_HASHES_SQL = "SELECT hash FROM SIGNED_NODE_INFOS;"
+
+        private const val DELETE_ALL_NODE_INFO_SQL =
+                "DELETE FROM SIGNED_NODE_INFOS;"
     }
 }
 


### PR DESCRIPTION
1.  Updated the readme with a few tidbits others may find helpful.
2.  NetworkMapApi.kt: Added a network-map/map-stats HTTP GET method that returns the legalName of the published nodeInfo(s) and notary(s) - helpful in debugging network config and initialization.
3.  NetworkMapApi.kt: Added a network-map/ HTTP GET method that will reset the published nodeInfo(s) and return the number of records deleted.
4.  NetworkMapApi.kt: Added logging to the NetworkMapApi.kt
5. NodInfoRepository.kt & SqlLiteNodeInfoRepository.kt: added purgeAllPersistedSignedNodeInfos() : Int signature and operation, respectively.