### PR TITLE
Enable class info for classpath scanning

### DIFF
--- a/src/main/kotlin/net/corda/network/map/whitelist/JarLoader.kt
+++ b/src/main/kotlin/net/corda/network/map/whitelist/JarLoader.kt
@@ -45,6 +45,7 @@ class JarLoader(@Value("\${jars.location:/jars}") jarDir: String?) {
         override val hash: SecureHash by lazy(LazyThreadSafetyMode.NONE, file::hash)
         override fun scan(): List<ContractClassName> {
             val scanResult = ClassGraph()
+                    .enableClassInfo()
                     // A set of a single element may look odd, but if this is removed "Path" which itself is an `Iterable`
                     // is getting broken into pieces to scan individually, which doesn't yield desired effect.
                     .overrideClasspath(Collections.singleton(file))


### PR DESCRIPTION
ClassGraph requires to explicitly enable the type on information that needs to be accessed during scanning. I enabled class-level info for the cordapp jars.

Otherwise, during startup, the following exception is raised:
```
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [net.corda.network.map.NetworkMapApi]: Constructor threw exception; nested exception is java.lang.IllegalArgumentException: Please call ClassGraph#enableClassInfo() before #scan()
...
Caused by: java.lang.IllegalArgumentException: Please call ClassGraph#enableClassInfo() before #scan()
	at io.github.classgraph.ScanResult.getClassesImplementing(ScanResult.java:654) ~[classgraph-4.4.12.jar!/:4.4.12]
	at net.corda.network.map.whitelist.JarLoader$ContractsJarFile.scan(JarLoader.kt:53) ~[classes!/:na]
	at net.corda.network.map.whitelist.JarLoader.generateWhitelist(JarLoader.kt:35) ~[classes!/:na]
	at net.corda.network.map.NetworkMapApi.<init>(NetworkMapApi.kt:104) ~[classes!/:na]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:1.8.0_191]
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[na:1.8.0_191]
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[na:1.8.0_191]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[na:1.8.0_191]
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:142) ~[spring-beans-4.3.14.RELEASE.jar!/:4.3.14.RELEASE]
```

I've tested by building the docker image again and re-running it.